### PR TITLE
Removing `Generated` function in runtimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale_signature_http"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "default http signature for Scale Runtime"
 license = "Apache-2.0"

--- a/context.rs
+++ b/context.rs
@@ -17,10 +17,12 @@
 use crate::http_signature::{HttpContext, HttpRequest, HttpResponse};
 use std::collections::HashMap;
 
+#[cfg(target_arch = "wasm32")]
 pub struct Context {
     pub(crate) generated: HttpContext,
 }
 
+#[cfg(target_arch = "wasm32")]
 pub fn new() -> Context {
     Context {
         generated: HttpContext {
@@ -41,3 +43,27 @@ pub fn new() -> Context {
         },
     }
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type Context = HttpContext;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn new() -> Context {
+    Context {
+        request: HttpRequest {
+            headers: HashMap::new(),
+            uri: "".to_string(),
+            method: "".to_string(),
+            content_length: 0,
+            protocol: "".to_string(),
+            ip: "".to_string(),
+            body: Vec::new(),
+        },
+        response: HttpResponse {
+            headers: HashMap::new(),
+            status_code: 0,
+            body: Vec::new(),
+        },
+    }
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopholelabs/scale-signature-http",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TypeScript version of the scale-signature-http.",
   "source": "index.ts",
   "main": "dist/main.js",

--- a/runtime.go
+++ b/runtime.go
@@ -31,22 +31,16 @@ type RuntimeContext Context
 // Context is a context object for an incoming request. It is meant to be used
 // inside the Scale function.
 type Context struct {
-	generated *HttpContext
-	buffer    *polyglot.Buffer
+	*HttpContext
+	buffer *polyglot.Buffer
 }
 
 // New creates a new empty Context
 func New() *Context {
 	return &Context{
-		generated: NewHttpContext(),
-		buffer:    polyglot.NewBuffer(),
+		HttpContext: NewHttpContext(),
+		buffer:      polyglot.NewBuffer(),
 	}
-}
-
-// Generated returns the underlying generated context object.
-// It is meant to be used by adapters and users should not use it.
-func (x *Context) Generated() *HttpContext {
-	return x.generated
 }
 
 // RuntimeContext converts a Context into a RuntimeContext.
@@ -58,19 +52,19 @@ func (x *Context) RuntimeContext() signature.RuntimeContext {
 //
 // This method is meant to be used by the Scale Runtime to deserialize the Context
 func (x *RuntimeContext) Read(b []byte) error {
-	return x.generated.internalDecode(b)
+	return x.internalDecode(b)
 }
 
 // Write writes the context into a byte slice and returns it
 func (x *RuntimeContext) Write() []byte {
 	x.buffer.Reset()
-	x.generated.internalEncode(x.buffer)
+	x.internalEncode(x.buffer)
 	return x.buffer.Bytes()
 }
 
 // Error writes the context into a byte slice and returns it
 func (x *RuntimeContext) Error(err error) []byte {
 	x.buffer.Reset()
-	x.generated.internalError(x.buffer, err)
+	x.internalError(x.buffer, err)
 	return x.buffer.Bytes()
 }

--- a/runtime.rs
+++ b/runtime.rs
@@ -23,12 +23,6 @@ use std::io::Cursor;
 
 pub type RuntimeContext = Context;
 
-impl Context {
-    pub fn generated(&self) -> &HttpContext {
-        &self.generated
-    }
-}
-
 impl SignatureTrait for Context {
     fn runtime_context(&mut self) -> &mut dyn RuntimeContextTrait {
         self
@@ -41,7 +35,7 @@ impl RuntimeContextTrait for RuntimeContext {
         let result = HttpContext::decode(&mut cursor);
         return match result {
             Ok(context) => {
-                self.generated = context.unwrap();
+                *self = context.unwrap();
                 None
             }
             Err(err) => Some(err),
@@ -50,13 +44,13 @@ impl RuntimeContextTrait for RuntimeContext {
 
     fn write(&self) -> Vec<u8> {
         let mut cursor = Cursor::new(Vec::new());
-        let _ = Encode::encode(self.generated.clone(), &mut cursor);
+        let _ = Encode::encode(self.clone(), &mut cursor);
         cursor.into_inner()
     }
 
     fn error(&self, error: Box<dyn std::error::Error>) -> Vec<u8> {
         let mut cursor = Cursor::new(Vec::new());
-        Encode::internal_error(self.generated.clone(), &mut cursor, error);
+        Encode::internal_error(self.clone(), &mut cursor, error);
         cursor.into_inner()
     }
 }

--- a/runtime.ts
+++ b/runtime.ts
@@ -28,14 +28,12 @@ export function New(): Context {
     return new Context();
 }
 
-export class Context implements Signature {
-    private readonly generated = new HttpContext(new HttpRequest("", "", BigInt(0), "", "", EmptyBytes, new Map<string, StringList>()), new HttpResponse(0, EmptyBytes, new Map<string, StringList>()));
-    private readonly runtimeContext = new RuntimeContext(this.generated);
+export class Context extends HttpContext implements Signature {
+    private readonly runtimeContext: RuntimeContext;
 
-   constructor() {}
-
-   Generated(): HttpContext {
-     return this.generated;
+   constructor() {
+        super(new HttpRequest("", "", BigInt(0), "", "", EmptyBytes, new Map<string, StringList>()), new HttpResponse(0, EmptyBytes, new Map<string, StringList>()));
+        this.runtimeContext = new RuntimeContext(this);
    }
 
    RuntimeContext(): RuntimeContext {


### PR DESCRIPTION
We previously kept a `Generated` function in our runtime signature implementations since the runtime often needed to modify and all parts of the signature object (including parts we wouldn't want the guest to be able to modify). 

Instead, we're this PR makes it so that the signature exports the type directly for just the runtime. 